### PR TITLE
Add workflow to regenerate hockey drills HTML

### DIFF
--- a/.github/workflows/update-drills-html.yml
+++ b/.github/workflows/update-drills-html.yml
@@ -1,0 +1,44 @@
+name: Update Hockey Drills HTML
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-html:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Generate hockey drills HTML
+        run: python drill_converter.py
+
+      - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add hockey_drills.html
+            git commit -m "chore: update generated hockey drills HTML"
+            git push
+          else
+            echo "No changes to commit"

--- a/hockey_drills.html
+++ b/hockey_drills.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Practice Drills</title>
+    <title>Hockey Drills Database</title>
     <style>
         /* ===== Design Tokens (Light) ===== */
         :root {
@@ -458,7 +458,8 @@
         <!-- ===== Hero Section ===== -->
         <section class="hero">
             <div class="container">
-                <h1>Practice Drills</h1>
+                <h1>Hockey Drills Database</h1>
+                <p>Search and filter through 88 professional hockey drills with 30 categories</p>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that regenerates the hockey drills HTML on pushes to main and manual runs
- configure the workflow to commit updated HTML back to the repository when changes are detected
- refresh the generated hockey_drills.html using the latest CSV data

## Testing
- python3 drill_converter.py

------
https://chatgpt.com/codex/tasks/task_e_68cb33a51484832b9495fc7672876845